### PR TITLE
Add simple portfolio website

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Jeremiah's Portfolio</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <header>
+        <h1>Jeremiah</h1>
+        <p>Motion & Interaction Designer</p>
+    </header>
+
+    <section class="intro fade">
+        <h2>Welcome</h2>
+        <p>After 5 years at Meizu crafting smooth experiences for mobile, auto, XR and more, I'm building my own playground.</p>
+    </section>
+
+    <section class="projects fade">
+        <h2>Projects</h2>
+        <p>Here I'll showcase some of my favorite work.</p>
+    </section>
+
+    <footer>
+        <p>&copy; 2023 Jeremiah</p>
+    </footer>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,16 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const observer = new IntersectionObserver(entries => {
+        entries.forEach(entry => {
+            if (entry.isIntersecting) {
+                entry.target.classList.add('visible');
+                observer.unobserve(entry.target);
+            }
+        });
+    }, {
+        threshold: 0.2
+    });
+
+    document.querySelectorAll('.fade').forEach(section => {
+        observer.observe(section);
+    });
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,37 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+    background: #fafafa;
+    color: #333;
+    scroll-behavior: smooth;
+}
+
+header {
+    background: #111;
+    color: #fff;
+    padding: 60px 20px;
+    text-align: center;
+}
+
+section {
+    padding: 80px 20px;
+    max-width: 800px;
+    margin: 0 auto;
+}
+
+footer {
+    text-align: center;
+    padding: 40px 20px;
+}
+
+.fade {
+    opacity: 0;
+    transform: translateY(20px);
+    transition: opacity 0.6s ease, transform 0.6s ease;
+}
+
+.fade.visible {
+    opacity: 1;
+    transform: translateY(0);
+}


### PR DESCRIPTION
## Summary
- scaffold a small portfolio site for Jeremiah with index, styles and script
- smooth fade-in transitions for sections using Intersection Observer

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683fa93e3da48329a770b32113f014bf